### PR TITLE
Added methods clearOn*Listener()

### DIFF
--- a/library/src/main/java/io/github/kobakei/materialfabspeeddial/FabSpeedDial.java
+++ b/library/src/main/java/io/github/kobakei/materialfabspeeddial/FabSpeedDial.java
@@ -592,6 +592,13 @@ public class FabSpeedDial extends FrameLayout {
     }
 
     /**
+     * Remove all event listeners
+     */
+    public void clearOnMenuItemClickListeners() {
+        menuClickListeners.clear();
+    }
+
+    /**
      * Add event listener
      * @param listener
      */
@@ -605,6 +612,13 @@ public class FabSpeedDial extends FrameLayout {
      */
     public void removeOnStateChangeListener(OnStateChangeListener listener) {
         stateChangeListeners.remove(listener);
+    }
+
+    /**
+     * Remove all event listener
+     */
+    public void clearOnStateChangeListeners() {
+        stateChangeListeners.clear();
     }
 
     /**


### PR DESCRIPTION
I hope this turns out right, I didn't do this in a proper IDE. I'd like to be able to remove all existing listeners without having to know the exact listener objects.

Reason:
I use one FAB in my activity with different content for different fragments, where the fragments set up the FAB speed dial. It would be rather tedious to remember the other listeners just to remove them.